### PR TITLE
handle invalid encoding in the pure ruby version of CGI.escapeHTML and CGI.unescapeHTML

### DIFF
--- a/lib/cgi/util.rb
+++ b/lib/cgi/util.rb
@@ -49,9 +49,12 @@ module CGI::Util
       table = Hash[TABLE_FOR_ESCAPE_HTML__.map {|pair|pair.map {|s|s.encode(enc)}}]
       string = string.gsub(/#{"['&\"<>]".encode(enc)}/, table)
       string.encode!(origenc) if origenc
-      return string
+      string
+    else
+      string = string.b
+      string.gsub!(/['&\"<>]/, TABLE_FOR_ESCAPE_HTML__)
+      string.force_encoding(enc)
     end
-    string.gsub(/['&\"<>]/, TABLE_FOR_ESCAPE_HTML__)
   end
 
   begin
@@ -90,7 +93,8 @@ module CGI::Util
                 when Encoding::ISO_8859_1; 256
                 else 128
                 end
-    string.gsub(/&(apos|amp|quot|gt|lt|\#[0-9]+|\#[xX][0-9A-Fa-f]+);/) do
+    string = string.b
+    string.gsub!(/&(apos|amp|quot|gt|lt|\#[0-9]+|\#[xX][0-9A-Fa-f]+);/) do
       match = $1.dup
       case match
       when 'apos'                then "'"
@@ -116,6 +120,7 @@ module CGI::Util
         "&#{match};"
       end
     end
+    string.force_encoding enc
   end
 
   # Synonym for CGI.escapeHTML(str)


### PR DESCRIPTION
the pure ruby version should behave the same way as the native extension

spec https://github.com/ruby/spec/pull/759 and https://github.com/ruby/spec/pull/782

note that the failure can be observed only in case when the native extension can't be loaded or with alternative ruby implementations