### PR TITLE
gemspec: Explicitly empty executables list

### DIFF
--- a/cgi.gemspec
+++ b/cgi.gemspec
@@ -26,6 +26,6 @@ Gem::Specification.new do |spec|
     `git ls-files -z 2>/dev/null`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end
   spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.executables   = []
   spec.require_paths = ["lib"]
 end


### PR DESCRIPTION
The gem exposes no executables