### PR TITLE
CI: Use bundler-cache from ruby/setup-ruby

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,6 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
-    - name: Install dependencies
-      run: bundle install
+        bundler-cache: true # 'bundle install' and cache gems
     - name: Run test
-      run: rake test
+      run: bundle exec rake test


### PR DESCRIPTION
This PR uses the `bundler-cache` feature of the Ruby-maintained Action ruby/setup-ruby.

[See `ruby/setup-ruby`](https://github.com/ruby/setup-ruby/blob/master/action.yml) for more information.