### PR TITLE
Optimize the no-escape case with strpbrk

### DIFF
--- a/ext/cgi/escape/escape.c
+++ b/ext/cgi/escape/escape.c
@@ -45,6 +45,11 @@ escaped_length(VALUE str)
 static VALUE
 optimized_escape_html(VALUE str)
 {
+    // Use strpbrk to optimize the no-escape case when str is long enough for SIMD.
+    if (RSTRING_LEN(str) >= 16 && strpbrk(RSTRING_PTR(str), "'&\"<>") == NULL) {
+        return rb_str_dup(str);
+    }
+
     VALUE vbuf;
     char *buf = ALLOCV_N(char, vbuf, escaped_length(str));
     const char *cstr = RSTRING_PTR(str);


### PR DESCRIPTION
in case you're interested in applying https://github.com/ruby/erb/pull/29 to `CGI.escapeHTML` as well.

It's a trade-off; the results are different across different benchmarks, but it makes the `long_no_escape` case significantly faster while nothing becomes too slower.

```
$ benchmark-driver benchmark/cgi_escape_html.yml -v --rbenv 'before;after' --repeat-count=4
before: ruby 3.2.0dev (2022-11-05T06:54:25Z master f276d5a7fe) [x86_64-linux]
after: ruby 3.2.0dev (2022-11-05T07:13:07Z master 6b12050456) [x86_64-linux]
last_commit=[ruby/cgi] Optimize the no-escape case with strpbrk
Calculating -------------------------------------
                                    before       after
             CGI.escapeHTML("")    22.426M     22.241M i/s -     20.000M times in 0.891821s 0.899255s
        CGI.escapeHTML("abcde")    22.581M     20.388M i/s -     20.000M times in 0.885703s 0.980992s
        CGI.escapeHTML("abcd<")    18.340M     17.042M i/s -     20.000M times in 1.090511s 1.173585s
       CGI.escapeHTML("'&\"<>")    16.914M     15.893M i/s -      5.000M times in 0.295606s 0.314608s
 CGI.escapeHTML(long_no_escape)     1.846M      8.863M i/s -      1.000M times in 0.541767s 0.112832s
CGI.escapeHTML(long_all_escape)     9.744M      8.536M i/s -      1.000M times in 0.102631s 0.117157s
   CGI.escapeHTML(example_html)     4.382M      3.596M i/s -      1.000M times in 0.228197s 0.278075s

Comparison:
                          CGI.escapeHTML("")
                         before:  22426027.9 i/s
                          after:  22240623.5 i/s - 1.01x  slower

                     CGI.escapeHTML("abcde")
                         before:  22580928.0 i/s
                          after:  20387524.6 i/s - 1.11x  slower

                     CGI.escapeHTML("abcd<")
                         before:  18340020.2 i/s
                          after:  17041799.5 i/s - 1.08x  slower

                    CGI.escapeHTML("'&\"<>")
                         before:  16914426.1 i/s
                          after:  15892785.0 i/s - 1.06x  slower

              CGI.escapeHTML(long_no_escape)
                          after:   8862762.4 i/s
                         before:   1845811.8 i/s - 4.80x  slower

             CGI.escapeHTML(long_all_escape)
                         before:   9743670.2 i/s
                          after:   8535559.7 i/s - 1.14x  slower

                CGI.escapeHTML(example_html)
                         before:   4382178.9 i/s
                          after:   3596148.7 i/s - 1.22x  slower
```