### PR TITLE
Loosen the domain regex to accept '.'

### DIFF
--- a/lib/cgi/cookie.rb
+++ b/lib/cgi/cookie.rb
@@ -42,7 +42,7 @@ class CGI
 
     TOKEN_RE = %r"\A[[!-~]&&[^()<>@,;:\\\"/?=\[\]{}]]+\z"
     PATH_VALUE_RE = %r"\A[[ -~]&&[^;]]*\z"
-    DOMAIN_VALUE_RE = %r"\A(?<label>(?!-)[-A-Za-z0-9]+(?<!-))(?:\.\g<label>)*\z"
+    DOMAIN_VALUE_RE = %r"\A(?<label>(?!-)\.?[-A-Za-z0-9]+(?<!-))(?:\.\g<label>)*\z"
 
     # Create a new CGI::Cookie object.
     #

--- a/lib/cgi/cookie.rb
+++ b/lib/cgi/cookie.rb
@@ -42,7 +42,7 @@ class CGI
 
     TOKEN_RE = %r"\A[[!-~]&&[^()<>@,;:\\\"/?=\[\]{}]]+\z"
     PATH_VALUE_RE = %r"\A[[ -~]&&[^;]]*\z"
-    DOMAIN_VALUE_RE = %r"\A(?<label>(?!-)\.?[-A-Za-z0-9]+(?<!-))(?:\.\g<label>)*\z"
+    DOMAIN_VALUE_RE = %r"\A\.?(?<label>(?!-)[-A-Za-z0-9]+(?<!-))(?:\.\g<label>)*\z"
 
     # Create a new CGI::Cookie object.
     #

--- a/test/cgi/test_cgi_cookie.rb
+++ b/test/cgi/test_cgi_cookie.rb
@@ -65,6 +65,9 @@ class CGICookieTest < Test::Unit::TestCase
     cookie = CGI::Cookie.new('domain'=>'a.example.com', **h)
     assert_equal('a.example.com', cookie.domain)
 
+    cookie = CGI::Cookie.new('domain'=>'.example.com', **h)
+    assert_equal('.example.com', cookie.domain)
+
     cookie = CGI::Cookie.new('domain'=>'1.example.com', **h)
     assert_equal('1.example.com', cookie.domain, 'enhanced by RFC 1123')
 


### PR DESCRIPTION
Domain leading with `.` should be allowed since it represents all subdomain are sharing the same cookie. 
