### PR TITLE
Load cgi/util only with test_cgi_util.rb

### DIFF
--- a/test/cgi/test_cgi_util.rb
+++ b/test/cgi/test_cgi_util.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 require 'test/unit'
-require 'cgi'
+require 'cgi/util'
 require 'stringio'
 require_relative 'update_env'
 


### PR DESCRIPTION
I have a plan to separate `cgi` and `cgi-util` in the future. This change is preparation for that.

We may not separate `cgi` and `cgi-util`, but `cgi/util` should work without `require 'cgi'`.