### PR TITLE
Fix reference error of @@accept_charset class variable.

### DIFF
--- a/lib/cgi.rb
+++ b/lib/cgi.rb
@@ -291,8 +291,8 @@ class CGI
   VERSION = "0.5.0.beta1"
 end
 
-require 'cgi/core'
-require 'cgi/cookie'
 require 'cgi/util'
 require 'cgi/escape' unless defined?(CGI::EscapeExt)
+require 'cgi/core'
+require 'cgi/cookie'
 CGI.autoload(:HtmlExtension, 'cgi/html')


### PR DESCRIPTION
```
Error: test_cgi_multipart_stringio(CGIMultipartTest): RuntimeError: class variable @@accept_charset of CGI is overtaken by CGI::Escape
/Users/hsbt/Documents/github.com/ruby/cgi/lib/cgi/core.rb:852:in 'initialize'
org/jruby/RubyClass.java:1023:in 'new'
```