### PR TITLE
Remove an unnecessary `each` call

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
   ruby-versions:
     uses: ruby/actions/.github/workflows/ruby_versions.yml@master
     with:
-      min_version: 2.5
+      min_version: 2.6
   test:
     needs: ruby-versions
     name: build (${{ matrix.ruby }} / ${{ matrix.os }})
@@ -16,7 +16,6 @@ jobs:
         ruby: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
         os: [ ubuntu-latest, macos-latest, windows-latest ]
         exclude:
-          - { os: macos-latest, ruby: 2.5 }
           - { os: windows-latest, ruby: head }
           - { os: macos-latest, ruby: jruby }
           - { os: windows-latest, ruby: jruby }

--- a/cgi.gemspec
+++ b/cgi.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.description   = %q{Support for the Common Gateway Interface protocol.}
   spec.homepage      = "https://github.com/ruby/cgi"
   spec.licenses      = ["Ruby", "BSD-2-Clause"]
-  spec.required_ruby_version = ">= 2.5.0"
+  spec.required_ruby_version = ">= 2.6.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage

--- a/lib/cgi/core.rb
+++ b/lib/cgi/core.rb
@@ -392,7 +392,7 @@ class CGI
   #
   def self.parse(query)
     params = {}
-    query.split(/[&;]/).each do |pairs|
+    query.split(/[&;]/) do |pairs|
       key, value = pairs.split('=',2).collect{|v| CGI.unescape(v) }
 
       next unless key


### PR DESCRIPTION
`String#split` yields each element if the block is given, since ruby 2.6.