### PR TITLE
Fix Use of a broken or weak cryptographic hashing algorithm on sensitive data

### DIFF
--- a/lib/cgi/session.rb
+++ b/lib/cgi/session.rb
@@ -214,11 +214,11 @@ class CGI
       dir = option['tmpdir'] || Dir::tmpdir
       prefix = option['prefix']
       suffix = option['suffix']
-      require 'digest/md5'
-      md5 = Digest::MD5.hexdigest(session_id)[0,16]
+      require 'digest'
+      sha256 = Digest::SHA256.hexdigest(session_id)[0,16]
       path = dir+"/"
       path << prefix if prefix
-      path << md5
+      path << sha256
       path << suffix if suffix
       if File::exist? path
         hash = nil


### PR DESCRIPTION
Fix the problem, replace the use of MD5 with a strong cryptographic hash function, such as SHA-256, for hashing the session ID. This change should be made in the `new_store_file` method, where the hash is computed for the session ID. Specifically, replace `require 'digest/md5'` and `Digest::MD5.hexdigest(session_id)[0,16]` with `require 'digest'` and `Digest::SHA256.hexdigest(session_id)[0,16]`. This ensures that a strong hash function is used, reducing the risk of collisions and improving security. No other changes are needed, as the hash is still truncated to 16 characters for filename purposes.
