### PR TITLE
test/cgi/test_cgi_escape.rb: Suppress Ruby warnings about pattern matching from power_assert

### DIFF
--- a/test/cgi/test_cgi_escape.rb
+++ b/test/cgi/test_cgi_escape.rb
@@ -63,7 +63,7 @@ class CGIEscapeTest < Test::Unit::TestCase
     return unless defined?(::Encoding)
 
     assert_raise(TypeError) {CGI.unescape('', nil)}
-    assert_separately(%w[-rcgi/escape], "#{<<-"begin;"}\n#{<<-"end;"}")
+    assert_separately(%w[-W0 -rcgi/escape], "#{<<-"begin;"}\n#{<<-"end;"}")
     begin;
       assert_equal("", CGI.unescape(''))
     end;
@@ -120,7 +120,7 @@ class CGIEscapeTest < Test::Unit::TestCase
     return unless defined?(::Encoding)
 
     assert_raise(TypeError) {CGI.unescapeURIComponent('', nil)}
-    assert_separately(%w[-rcgi/escape], "#{<<-"begin;"}\n#{<<-"end;"}")
+    assert_separately(%w[-W0 -rcgi/escape], "#{<<-"begin;"}\n#{<<-"end;"}")
     begin;
       assert_equal("", CGI.unescapeURIComponent(''))
     end;


### PR DESCRIPTION
This PR uses `-W0` in two tests that assert output.

Was a failed build in #86 in Ruby versions that do not support pattern matching.