### PR TITLE
[DOC] Fix examples in accept_charset and http_header docs

### DIFF
--- a/lib/cgi/core.rb
+++ b/lib/cgi/core.rb
@@ -953,16 +953,16 @@ class CGI
   # see {Encodings}[https://docs.ruby-lang.org/en/master/language/encodings_rdoc.html]:
   #
   #   # The initial value.
-  #   CGI.accept_charset # => "UTF-8"
+  #   CGI.accept_charset # => #<Encoding:UTF-8>
   #   CGI.new
   #   # =>
   #   #<CGI:0x0000018991db6ae8
-  #    @accept_charset="UTF-8",
+  #    @accept_charset=#<Encoding:UTF-8>,
   #    @accept_charset_error_block=nil,
   #    @cookies={},
   #    @max_multipart_length=134217728,
   #    @multipart=false,
-  #    @options={accept_charset: "UTF-8", max_multipart_length: 134217728},
+  #    @options={accept_charset: #<Encoding:UTF-8>, max_multipart_length: 134217728},
   #    @output_cookies=nil,
   #    @output_hidden=nil,
   #    @params={}>
@@ -1045,12 +1045,12 @@ class CGI
   #   cgi
   #   # =>
   #   #<CGI:0x00000189917aff00
-  #    @accept_charset="UTF-8",
+  #    @accept_charset=#<Encoding:UTF-8>,
   #    @accept_charset_error_block=nil,
   #    @cookies={},
   #    @max_multipart_length=134217728,
   #    @multipart=false,
-  #    @options={accept_charset: "UTF-8", max_multipart_length: 134217728},
+  #    @options={accept_charset: #<Encoding:UTF-8>, max_multipart_length: 134217728},
   #    @output_cookies=nil,
   #    @output_hidden=nil,
   #    @params={}>

--- a/lib/cgi/core.rb
+++ b/lib/cgi/core.rb
@@ -134,7 +134,7 @@ class CGI
   #   Content-Type: text/html
   #
   # With string argument +content_type+ given,
-  # includes header +Content-Type+ with its default value <tt>'text/html'</tt>:
+  # includes header +Content-Type+ with the given value:
   #
   #   puts cgi.http_header('text/xml')
   #   Content-Type: text/xml
@@ -214,7 +214,7 @@ class CGI
   #     Content-Language: en-US, en-CA
   #
   # <tt>'length'</tt>::
-  #   Sets header +Content-Length+ the given value,
+  #   Sets header +Content-Length+ to the given value,
   #   which may be an integer or a string:
   #
   #     puts cgi.http_header('length' =>  4096)
@@ -228,7 +228,7 @@ class CGI
   # <tt>'nph'</tt>::
   #   If +true+:
   #
-  #   - Adds protocol string and status code as first line,
+  #   - Adds protocol string and status code as first line.
   #   - Adds date as second line.
   #   - Adds headers +Server+ with no value,
   #     and +Connection+ with default value <tt>'close'</tt>;


### PR DESCRIPTION
Follow-up to the recently merged documentation work in #95, #97, and #98.

The accept_charset examples showed the default value as the string "UTF-8". Requiring 'cgi' loads the cgi/escape extension, which initializes @@accept_charset to Encoding::UTF_8, so the real inspect output is #<Encoding:UTF-8>. The examples now reflect that.

The http_header documentation said the string content_type argument uses "its default value" while its own example passes and prints text/xml, so it now says the given value is used. The 'length' key description was also missing "to".
