### PR TITLE
Remove flaky test_escape_html_allocates_same_as_escapeHTML

### DIFF
--- a/test/cgi/test_cgi_escape.rb
+++ b/test/cgi/test_cgi_escape.rb
@@ -353,30 +353,6 @@ class CGIEscapeNativeExtTest < Test::Unit::TestCase
     assert_equal CGI::EscapeExt, CGI.method(:h).owner
     assert_equal CGI::EscapeExt, CGI.method(:unescape_html).owner
   end
-
-  def test_escape_html_allocates_same_as_escapeHTML
-    omit "C extension not available" unless defined?(CGI::EscapeExt) && CGI::EscapeExt.method_defined?(:escapeHTML)
-
-    input = "'&\"<>hello world"
-    n = 100
-
-    # Warm up
-    2.times { n.times { CGI.escapeHTML(input) } }
-    2.times { n.times { CGI.escape_html(input) } }
-
-    GC.disable
-    before = GC.stat(:total_allocated_objects)
-    n.times { CGI.escapeHTML(input) }
-    camel_allocs = GC.stat(:total_allocated_objects) - before
-
-    before = GC.stat(:total_allocated_objects)
-    n.times { CGI.escape_html(input) }
-    snake_allocs = GC.stat(:total_allocated_objects) - before
-    GC.enable
-
-    assert_equal camel_allocs, snake_allocs,
-      "escape_html allocated #{snake_allocs} objects vs escapeHTML #{camel_allocs} — alias may not be using the C extension"
-  end
 end
 
 class CGIEscapePureRubyTest < Test::Unit::TestCase


### PR DESCRIPTION
It's causing [ruby CI to flake](https://github.com/ruby/ruby/actions/runs/28114103043/job/83248923275#step:12:920), because it's a badly designed test, a lot of thing can cause acouple extra allocation there and there so even if you invoke the exact same code twice, you might still allocate a bit more or a bit less.